### PR TITLE
More Idiomatic Optional Handlilng

### DIFF
--- a/Sources/gather/gather.swift
+++ b/Sources/gather/gather.swift
@@ -24,8 +24,8 @@ var unicodeSnob = true
 var wrapWidth = 0
 
 func exitWithError(error: Int32, message: String? = nil) {
-    if message != nil {
-        print(message!)
+    if let message {
+        print(message)
     }
     exit(error)
 }
@@ -33,9 +33,9 @@ func exitWithError(error: Int32, message: String? = nil) {
 func get_title(html: String?, url: String?) -> String? {
     var title = String?(nil)
 
-    if html != nil {
+    if let html {
         do {
-            let readability = Readability(html: html!)
+            let readability = Readability(html: html)
             let started = readability.start()
 
             if started {
@@ -46,8 +46,8 @@ func get_title(html: String?, url: String?) -> String? {
             print("Error parsing page")
             return title
         }
-    } else if url != nil {
-        let u = url!.replacingOccurrences(of: "[?&]utm_[^#]+", with: "", options: .regularExpression)
+    } else if let url {
+        let u = url.replacingOccurrences(of: "[?&]utm_[^#]+", with: "", options: .regularExpression)
         guard let page = try? String(contentsOf: URL(string: u)!, encoding: .utf8) else {
             return title
         }
@@ -71,8 +71,8 @@ func markdownify_input(html: String?, read: Bool?) -> (String?, String, String?)
 
 func countH1s(_ s: String, title: String?) -> Int {
     var pattern = "^# ."
-    if title != nil {
-        pattern = "^# \(NSRegularExpression.escapedPattern(for: title!))"
+    if let title {
+        pattern = "^# \(NSRegularExpression.escapedPattern(for: title))"
     }
 
     let re = try! NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines, .caseInsensitive])
@@ -81,13 +81,12 @@ func countH1s(_ s: String, title: String?) -> Int {
 }
 
 func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String? = "") -> (String?, String, String?) {
-    var html = html
     var title = String?(nil)
     var sourceUrl = url
 
-    if html != nil {
+    if var html {
         do {
-            let readability = Readability(html: html!)
+            let readability = Readability(html: html)
             readability.allSpecialHandling = true
             readability.acceptedAnswerOnly = acceptedAnswerOnly
             readability.includeAnswerComments = includeAnswerComments
@@ -103,7 +102,7 @@ func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String?
 
                 if read != false {
                     html = try readability.getContent()!.html()
-                    html = html!.trimmingCharacters(in: .whitespacesAndNewlines)
+                    html = html.trimmingCharacters(in: .whitespacesAndNewlines)
                 }
             }
 
@@ -121,15 +120,15 @@ func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String?
         h.escape_snob = escapeSpecial
         h.body_width = wrapWidth
 
-        let data = html!
+        let data = html
 
         let html2textresult = h.main(baseurl: baseurl ?? "", data: data)
 
         html = html2textresult.replacingOccurrences(of: #"([*-+] .*?)\n+(?=[*-+] )"#, with: "$1\n", options: .regularExpression)
 
-        html = html!.replacingOccurrences(of: #"(?m)\n{2,}"#, with: "\n\n")
+        html = html.replacingOccurrences(of: #"(?m)\n{2,}"#, with: "\n\n")
 
-        html = html!.replacingOccurrences(of: "__BR__", with: "  ")
+        html = html.replacingOccurrences(of: "__BR__", with: "  ")
 
         var source = ""
         var meta = ""
@@ -140,8 +139,8 @@ func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String?
             }
             let date = iso_datetime()
 
-            if title != nil {
-                meta += "title: \"\(title!)\""
+            if let title {
+                meta += "title: \"\(title)\""
             } else {
                 if titleFallback.isEmpty {
                     meta += "title: Clipped on \(date)"
@@ -150,8 +149,8 @@ func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String?
                 }
             }
 
-            if sourceUrl != nil {
-                meta += "\nsource: \(sourceUrl!)"
+            if let sourceUrl {
+                meta += "\nsource: \(sourceUrl)"
             }
 
             meta += "\ndate: \(date)"
@@ -162,22 +161,22 @@ func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String?
             }
         }
 
-        if includeSourceLink, sourceUrl != nil {
-            if title != nil {
+        if includeSourceLink, let sourceUrl {
+            if let title {
                 if includeTitleAsH1 {
-                    source = "# \(title!)\n\n[Source](\(sourceUrl!) \"\(title!)\")\n\n"
+                    source = "# \(title)\n\n[Source](\(sourceUrl) \"\(title)\")\n\n"
                 } else {
-                    source = "[Source](\(sourceUrl!) \"\(title!)\")\n\n"
+                    source = "[Source](\(sourceUrl) \"\(title)\")\n\n"
                 }
             } else {
-                source = "[Source](\(sourceUrl!))\n\n"
+                source = "[Source](\(sourceUrl))\n\n"
             }
-        } else if title != nil, includeTitleAsH1 {
-            source = "# \(title!)\n\n"
+        } else if let title, includeTitleAsH1 {
+            source = "# \(title)\n\n"
         }
-        html = "\(meta)\(source)\(html!)"
+        html = "\(meta)\(source)\(html)"
 
-        return (title, html!, sourceUrl)
+        return (title, html, sourceUrl)
     }
 
     return (title, "", url)
@@ -600,7 +599,7 @@ struct Gather: ParsableCommand {
         var markdown: String
         var sourceUrl: String?
 
-        if input != nil {
+        if let input {
             (title, markdown, sourceUrl) = markdownify_input(html: input, read: readability)
         } else if url != "" {
             (title, markdown, sourceUrl) = markdownify(url: url, read: readability)

--- a/Sources/gather/gather.swift
+++ b/Sources/gather/gather.swift
@@ -64,7 +64,7 @@ func iso_datetime() -> String {
     return dateFormatterPrint.string(from: Date())
 }
 
-func markdownify_input(html: String?, read: Bool?) -> (String?, String, String?) {
+func markdownify_input(html: String?, read: Bool) -> (String?, String, String?) {
     let read = read
     return markdownify_html(html: html, read: read, url: nil)
 }
@@ -76,7 +76,7 @@ func countH1s(_ s: String, title: String?) -> Int {
     return re.matches(in: s, options: [], range: checkRange).count
 }
 
-func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String? = "") -> (String?, String, String?) {
+func markdownify_html(html: String?, read: Bool, url: String?, baseurl: String? = "") -> (String?, String, String?) {
     var title: String?
     var sourceUrl = url
 
@@ -99,7 +99,7 @@ func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String?
             }
             title = try readability.getTitle()?.text()
 
-            if read != false {
+            if read {
                 html = try readability.getContent()!.html()
                 html = html.trimmingCharacters(in: .whitespacesAndNewlines)
             }
@@ -178,7 +178,7 @@ func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String?
     return (title, html, sourceUrl)
 }
 
-func markdownify(url: String, read: Bool?) -> (String?, String, String?) {
+func markdownify(url: String, read: Bool) -> (String?, String, String?) {
     let cleanedURLString = url.replacingOccurrences(of: "[?&]utm_[^#]+", with: "", options: .regularExpression)
     guard let base = URL(string: cleanedURLString), var host = base.host else {
         exitWithError(error: 1, message: "error: invalid URL")

--- a/Sources/gather/gather.swift
+++ b/Sources/gather/gather.swift
@@ -179,8 +179,8 @@ func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String?
 }
 
 func markdownify(url: String, read: Bool?) -> (String?, String, String?) {
-    let u = url.replacingOccurrences(of: "[?&]utm_[^#]+", with: "", options: .regularExpression)
-    guard let base = URL(string: u), var host = base.host else {
+    let cleanedURLString = url.replacingOccurrences(of: "[?&]utm_[^#]+", with: "", options: .regularExpression)
+    guard let base = URL(string: cleanedURLString), var host = base.host else {
         exitWithError(error: 1, message: "error: invalid URL")
         return (nil, "", nil)
     }
@@ -199,7 +199,7 @@ func markdownify(url: String, read: Bool?) -> (String?, String, String?) {
         baseurl = "\(scheme)://\(host)"
     }
 
-    return markdownify_html(html: page, read: read, url: u, baseurl: baseurl)
+    return markdownify_html(html: page, read: read, url: cleanedURLString, baseurl: baseurl)
 }
 
 func urlEncodeQuery(string: String) -> String {

--- a/Sources/gather/gather.swift
+++ b/Sources/gather/gather.swift
@@ -180,12 +180,7 @@ func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String?
 
 func markdownify(url: String, read: Bool?) -> (String?, String, String?) {
     var url = url
-    var html: String?
     var baseurl = url
-
-    if html == nil {
-        return (nil, "No valid url, html or text was provided.", nil)
-    }
 
     let u = url.replacingOccurrences(of: "[?&]utm_[^#]+", with: "", options: .regularExpression)
     guard let base = URL(string: u) else {
@@ -207,10 +202,9 @@ func markdownify(url: String, read: Bool?) -> (String?, String, String?) {
         return (nil, "", nil)
     }
 
-    html = page
     url = u
 
-    return markdownify_html(html: html, read: read, url: url, baseurl: baseurl)
+    return markdownify_html(html: page, read: read, url: url, baseurl: baseurl)
 }
 
 func urlEncodeQuery(string: String) -> String {

--- a/Sources/gather/gather.swift
+++ b/Sources/gather/gather.swift
@@ -365,12 +365,8 @@ func readInput() -> String? {
     return input
 }
 
-func readEnv(variable: String) -> String? {
-    if let input = ProcessInfo.processInfo.environment[variable] {
-        return input
-    }
-
-    return ""
+func readEnv(variable: String) -> String {
+    ProcessInfo.processInfo.environment[variable] ?? ""
 }
 
 @main
@@ -571,9 +567,9 @@ struct Gather: ParsableCommand {
                 }
 
                 if html {
-                    input = readEnv(variable: env)!
+                    input = readEnv(variable: env)
                 } else {
-                    url = readEnv(variable: env)!
+                    url = readEnv(variable: env)
                 }
             } else {
                 if html {

--- a/Sources/gather/gather.swift
+++ b/Sources/gather/gather.swift
@@ -178,39 +178,37 @@ func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String?
     return (title, html, sourceUrl)
 }
 
-func markdownify(url: String?, read: Bool?) -> (String?, String, String?) {
+func markdownify(url: String, read: Bool?) -> (String?, String, String?) {
     var url = url
     var html: String?
     var baseurl = url
 
-    if url == nil, html == nil {
+    if html == nil {
         return (nil, "No valid url, html or text was provided.", nil)
     }
 
-    if url != nil {
-        let u = url!.replacingOccurrences(of: "[?&]utm_[^#]+", with: "", options: .regularExpression)
-        guard let base = URL(string: u) else {
-            exitWithError(error: 1, message: "error: invalid URL")
-            return (nil, "", nil)
-        }
-
-        let scheme = base.scheme
-        var host = base.host
-        if base.port != nil {
-            host = "\(host!):\(base.port!)"
-        }
-
-        if scheme != nil, host != nil {
-            baseurl = "\(scheme!)://\(host!)"
-        }
-
-        guard let page = try? String(contentsOf: URL(string: u)!, encoding: .utf8) else {
-            return (nil, "", nil)
-        }
-
-        html = page
-        url = u
+    let u = url.replacingOccurrences(of: "[?&]utm_[^#]+", with: "", options: .regularExpression)
+    guard let base = URL(string: u) else {
+        exitWithError(error: 1, message: "error: invalid URL")
+        return (nil, "", nil)
     }
+
+    let scheme = base.scheme
+    var host = base.host
+    if base.port != nil {
+        host = "\(host!):\(base.port!)"
+    }
+
+    if scheme != nil, host != nil {
+        baseurl = "\(scheme!)://\(host!)"
+    }
+
+    guard let page = try? String(contentsOf: URL(string: u)!, encoding: .utf8) else {
+        return (nil, "", nil)
+    }
+
+    html = page
+    url = u
 
     return markdownify_html(html: html, read: read, url: url, baseurl: baseurl)
 }

--- a/Sources/gather/gather.swift
+++ b/Sources/gather/gather.swift
@@ -31,7 +31,7 @@ func exitWithError(error: Int32, message: String? = nil) {
 }
 
 func get_title(html: String?, url: String?) -> String? {
-    var title = String?(nil)
+    var title: String?
 
     if let html {
         do {
@@ -70,18 +70,14 @@ func markdownify_input(html: String?, read: Bool?) -> (String?, String, String?)
 }
 
 func countH1s(_ s: String, title: String?) -> Int {
-    var pattern = "^# ."
-    if let title {
-        pattern = "^# \(NSRegularExpression.escapedPattern(for: title))"
-    }
-
+    let pattern = title != nil ? "^# \(NSRegularExpression.escapedPattern(for: title!))" : "^# ."
     let re = try! NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines, .caseInsensitive])
     let checkRange = NSRange(s.startIndex ..< s.endIndex, in: s)
     return re.matches(in: s, options: [], range: checkRange).count
 }
 
 func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String? = "") -> (String?, String, String?) {
-    var title = String?(nil)
+    var title: String?
     var sourceUrl = url
 
     guard var html else {
@@ -184,7 +180,7 @@ func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String?
 
 func markdownify(url: String?, read: Bool?) -> (String?, String, String?) {
     var url = url
-    var html = String?(nil)
+    var html: String?
     var baseurl = url
 
     if url == nil, html == nil {

--- a/Sources/gather/gather.swift
+++ b/Sources/gather/gather.swift
@@ -189,15 +189,10 @@ func markdownify(url: String, read: Bool?) -> (String?, String, String?) {
         return (nil, "", nil)
     }
 
-    var baseurl = url
-    let scheme = base.scheme
     if let port = base.port {
         host = "\(host):\(port)"
     }
-
-    if let scheme {
-        baseurl = "\(scheme)://\(host)"
-    }
+    let baseurl = base.scheme != nil ? "\(base.scheme!)://\(host)" : url
 
     return markdownify_html(html: page, read: read, url: cleanedURLString, baseurl: baseurl)
 }

--- a/Sources/gather/gather.swift
+++ b/Sources/gather/gather.swift
@@ -179,7 +179,6 @@ func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String?
 }
 
 func markdownify(url: String, read: Bool?) -> (String?, String, String?) {
-    var url = url
     var baseurl = url
 
     let u = url.replacingOccurrences(of: "[?&]utm_[^#]+", with: "", options: .regularExpression)
@@ -201,9 +200,7 @@ func markdownify(url: String, read: Bool?) -> (String?, String, String?) {
         return (nil, "", nil)
     }
 
-    url = u
-
-    return markdownify_html(html: page, read: read, url: url, baseurl: baseurl)
+    return markdownify_html(html: page, read: read, url: u, baseurl: baseurl)
 }
 
 func urlEncodeQuery(string: String) -> String {

--- a/Sources/gather/gather.swift
+++ b/Sources/gather/gather.swift
@@ -183,19 +183,18 @@ func markdownify(url: String, read: Bool?) -> (String?, String, String?) {
     var baseurl = url
 
     let u = url.replacingOccurrences(of: "[?&]utm_[^#]+", with: "", options: .regularExpression)
-    guard let base = URL(string: u) else {
+    guard let base = URL(string: u), var host = base.host else {
         exitWithError(error: 1, message: "error: invalid URL")
         return (nil, "", nil)
     }
 
     let scheme = base.scheme
-    var host = base.host
-    if base.port != nil {
-        host = "\(host!):\(base.port!)"
+    if let port = base.port {
+        host = "\(host):\(port)"
     }
 
-    if scheme != nil, host != nil {
-        baseurl = "\(scheme!)://\(host!)"
+    if let scheme {
+        baseurl = "\(scheme)://\(host)"
     }
 
     guard let page = try? String(contentsOf: URL(string: u)!, encoding: .utf8) else {

--- a/Sources/gather/gather.swift
+++ b/Sources/gather/gather.swift
@@ -197,7 +197,7 @@ func markdownify(url: String, read: Bool?) -> (String?, String, String?) {
         baseurl = "\(scheme)://\(host)"
     }
 
-    guard let page = try? String(contentsOf: URL(string: u)!, encoding: .utf8) else {
+    guard let page = try? String(contentsOf: base, encoding: .utf8) else {
         return (nil, "", nil)
     }
 

--- a/Sources/gather/gather.swift
+++ b/Sources/gather/gather.swift
@@ -237,10 +237,7 @@ func slugifyFile(name: String) -> String {
 }
 
 func createUrlScheme(template: String, markdown: String, title: String?, notebook: String?, source: String?) -> String {
-    var note_title = ""
-    if title != nil {
-        note_title = title!
-    }
+    let note_title = title ?? ""
     var url = template.replacingOccurrences(of: #"%title"#, with: urlEncodeQuery(string: note_title), options: [.regularExpression, .caseInsensitive])
     url = url.replacingOccurrences(of: #"%text"#, with: urlEncodeQuery(string: markdown), options: [.regularExpression, .caseInsensitive])
     url = url.replacingOccurrences(of: #"%notebook"#, with: urlEncodeQuery(string: notebook ?? ""), options: [.regularExpression, .caseInsensitive])

--- a/Sources/gather/gather.swift
+++ b/Sources/gather/gather.swift
@@ -179,14 +179,17 @@ func markdownify_html(html: String?, read: Bool?, url: String?, baseurl: String?
 }
 
 func markdownify(url: String, read: Bool?) -> (String?, String, String?) {
-    var baseurl = url
-
     let u = url.replacingOccurrences(of: "[?&]utm_[^#]+", with: "", options: .regularExpression)
     guard let base = URL(string: u), var host = base.host else {
         exitWithError(error: 1, message: "error: invalid URL")
         return (nil, "", nil)
     }
 
+    guard let page = try? String(contentsOf: base, encoding: .utf8) else {
+        return (nil, "", nil)
+    }
+
+    var baseurl = url
     let scheme = base.scheme
     if let port = base.port {
         host = "\(host):\(port)"
@@ -194,10 +197,6 @@ func markdownify(url: String, read: Bool?) -> (String?, String, String?) {
 
     if let scheme {
         baseurl = "\(scheme)://\(host)"
-    }
-
-    guard let page = try? String(contentsOf: base, encoding: .utf8) else {
-        return (nil, "", nil)
     }
 
     return markdownify_html(html: page, read: read, url: u, baseurl: baseurl)


### PR DESCRIPTION
Changes handling of optional values to be more Swifty. Specifically, for some value `let message: String?`, replace:

```swift
if message != nil {
    print(message!)
}
```

with:

```swift
if let message {
    print(message)
}
```

The change is trivial in the above example but helps prevent errors from creeping in when the code path is more complex.

Also:

- updates `markdownify_html(html:read:url:baseurl:) to return early if `html` is optional, allowing everything within the current `if html != nil {` to be un-nested
- updates the signature of `readEnv(variable:)` to reflect that is always returns a string
- makes the `read` parameter of various functions non-optional
- updates  `markdownify(url:read:)` to require a non-optional value for `url`, use more explicit variable names, and more concise logic